### PR TITLE
[codex] Harden Docker image and compose runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,28 @@
-FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/go:latest AS builder
-ARG TARGETARCH
-WORKDIR /app
-COPY go.mod ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -installsuffix cgo -o kindle-weather .
+# syntax=docker/dockerfile:1.7
 
-FROM cgr.dev/chainguard/static:latest
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/go:latest@sha256:3d8fa865f7382d566f7a13aa67a90b5f758637ab75776ecb76e3da10df13ad66 AS builder
+
+ARG TARGETARCH
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download && go mod verify
+
+COPY *.go ./
+COPY templates/ ./templates/
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s -w -buildid=" -o /out/kindle-weather .
+
+FROM cgr.dev/chainguard/static:latest@sha256:77d8b8925dc27970ec2f48243f44c7a260d52c49cd778288e4ee97566e0cb75b
+
 WORKDIR /app
-COPY --from=builder /app/kindle-weather .
-COPY css/ ./css/
-COPY font/ ./font/
+COPY --from=builder --chown=65532:65532 /out/kindle-weather /app/kindle-weather
+COPY --chown=65532:65532 css/ /app/css/
+COPY --chown=65532:65532 font/ /app/font/
+
+USER 65532:65532
 EXPOSE 8080
-USER nonroot
-ENTRYPOINT ["./kindle-weather"]
+HEALTHCHECK --interval=60s --timeout=5s --start-period=15s --retries=3 CMD ["/app/kindle-weather", "--healthcheck"]
+ENTRYPOINT ["/app/kindle-weather"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,11 @@ services:
     build: .
     container_name: kindle-weather
     restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     environment:
       - CACHE_EXPIRATION=1800
       - CACHE_CLEANUP_INTERVAL=3600
@@ -19,7 +24,7 @@ services:
     ports:
       - "8081:8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/ || exit 1"]
+      test: [ "CMD", "/app/kindle-weather", "--healthcheck" ]
       interval: 60s
       timeout: 5s
       retries: 3

--- a/kindle-weather.go
+++ b/kindle-weather.go
@@ -942,6 +942,10 @@ func generateTideSVG(predictions []TidePrediction) (template.HTML, error) {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--healthcheck" {
+		os.Exit(runHealthcheck())
+	}
+
 	if err := configureRuntime(); err != nil {
 		logJSON(logEntry{
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -1010,4 +1014,18 @@ func main() {
 			})
 		}
 	}
+}
+
+func runHealthcheck() int {
+	client := http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://127.0.0.1:8080/health")
+	if err != nil {
+		return 1
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 1
+	}
+	return 0
 }


### PR DESCRIPTION
## Summary

- Pin Chainguard builder and runtime images by digest for reproducible Docker builds.
- Reduce Docker builder inputs to Go sources and embedded templates instead of copying the whole repository.
- Use BuildKit cache mounts, verify downloaded Go modules, and strip/trim the built binary.
- Run the app as UID/GID 65532 with explicit runtime file ownership.
- Add a binary-based container healthcheck that works in the shell-less Chainguard static image.
- Harden Compose with a read-only filesystem, dropped Linux capabilities, and no-new-privileges.

## Why

The previous Dockerfile used floating `latest` images, copied the full repository into the builder, and the Compose healthcheck depended on `wget`, which is unavailable in the static runtime image. This makes builds less reproducible and can break container health reporting.

## Validation

- `go test ./...`
- `go vet ./...`
- `docker compose config`
- `docker compose build kindle-weather`
- Smoke-tested the image with `--read-only --cap-drop=ALL --security-opt=no-new-privileges:true`
- Verified `GET /health` returned healthy
- Verified the rendered page still includes refresh, tide, moon, and sunrise output
- Verified Docker marked the smoke container `healthy`

## Notes

The local `.github/workflows/ci.yaml` modification was intentionally left out of this PR because it appears unrelated to the Docker hardening work.
