### PR TITLE
[codex] add pre-merge e2e coverage

### DIFF
--- a/.github/scripts/e2e.sh
+++ b/.github/scripts/e2e.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+MOCK_PORT="${MOCK_PORT:-18080}"
+APP_URL="http://127.0.0.1:8080"
+MOCK_URL="http://127.0.0.1:${MOCK_PORT}"
+
+MOCK_PID=""
+APP_PID=""
+
+cleanup() {
+  if [[ -n "${APP_PID}" ]]; then
+    kill "${APP_PID}" >/dev/null 2>&1 || true
+    wait "${APP_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${MOCK_PID}" ]]; then
+    kill "${MOCK_PID}" >/dev/null 2>&1 || true
+    wait "${MOCK_PID}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${TMPDIR}"
+}
+trap cleanup EXIT
+
+wait_for_http() {
+  local url="$1"
+  local name="$2"
+  for _ in {1..60}; do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "Timed out waiting for ${name} at ${url}" >&2
+  if [[ -f "${TMPDIR}/app.log" ]]; then
+    echo "--- app.log ---" >&2
+    cat "${TMPDIR}/app.log" >&2
+  fi
+  if [[ -f "${TMPDIR}/mock.log" ]]; then
+    echo "--- mock.log ---" >&2
+    cat "${TMPDIR}/mock.log" >&2
+  fi
+  return 1
+}
+
+wait_for_http_down() {
+  local url="$1"
+  local name="$2"
+  for _ in {1..60}; do
+    if ! curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "Timed out waiting for ${name} to stop at ${url}" >&2
+  return 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq "${expected}" "${file}"; then
+    echo "Expected ${file} to contain: ${expected}" >&2
+    echo "--- ${file} ---" >&2
+    cat "${file}" >&2
+    return 1
+  fi
+}
+
+stop_app() {
+  if [[ -n "${APP_PID}" ]]; then
+    kill -INT "${APP_PID}" >/dev/null 2>&1 || true
+    wait "${APP_PID}" >/dev/null 2>&1 || true
+    APP_PID=""
+    wait_for_http_down "${APP_URL}/health" "kindle-weather"
+  fi
+}
+
+start_app() {
+  local tide_path="$1"
+  : > "${TMPDIR}/app.log"
+  (
+    cd "${ROOT}"
+    export OPENWEATHER_API_KEY=e2e
+    export WEATHER_API_URL="${MOCK_URL}/weather"
+    export NOAA_API_URL="${MOCK_URL}${tide_path}"
+    export SPACEDEVS_API_URL="${MOCK_URL}/launches/upcoming/"
+    export AUTO_REFRESH_SECONDS=60
+    export LAUNCH_API_TIMEOUT_SECONDS=5
+    exec "${TMPDIR}/kindle-weather"
+  ) > "${TMPDIR}/app.log" 2>&1 &
+  APP_PID="$!"
+  wait_for_http "${APP_URL}/health" "kindle-weather"
+}
+
+(
+  cd "${ROOT}"
+  go build -o "${TMPDIR}/kindle-weather" .
+)
+
+python3 "${ROOT}/.github/scripts/mock_api.py" --host 127.0.0.1 --port "${MOCK_PORT}" > "${TMPDIR}/mock.log" 2>&1 &
+MOCK_PID="$!"
+wait_for_http "${MOCK_URL}/health" "mock api"
+
+start_app "/tide"
+curl -fsS "${APP_URL}/" > "${TMPDIR}/page.html"
+curl -fsS "${APP_URL}/css/kindle.css" > "${TMPDIR}/kindle.css"
+curl -fsS "${APP_URL}/metrics" > "${TMPDIR}/metrics.txt"
+assert_contains "${TMPDIR}/page.html" "Weather & Tide"
+assert_contains "${TMPDIR}/page.html" "E2E clear skies"
+assert_contains "${TMPDIR}/page.html" "3:17 AM"
+assert_contains "${TMPDIR}/page.html" "9:24 AM"
+assert_contains "${TMPDIR}/page.html" "id=\"launches\""
+assert_contains "${TMPDIR}/kindle.css" ".tide-section"
+assert_contains "${TMPDIR}/metrics.txt" "http_requests_total"
+stop_app
+
+start_app "/tide-empty"
+curl -fsS "${APP_URL}/" > "${TMPDIR}/page-no-tide.html"
+assert_contains "${TMPDIR}/page-no-tide.html" "Weather & Tide"
+assert_contains "${TMPDIR}/page-no-tide.html" "E2E clear skies"
+assert_contains "${TMPDIR}/page-no-tide.html" "Tide data unavailable"
+stop_app
+
+echo "E2E checks passed"

--- a/.github/scripts/mock_api.py
+++ b/.github/scripts/mock_api.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import argparse
+import datetime as dt
+import json
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+
+def utc_timestamp(offset_seconds=0):
+    return int(time.time()) + offset_seconds
+
+
+def rfc3339_utc(offset_seconds=0):
+    value = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=offset_seconds)
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def weather_payload():
+    now = utc_timestamp()
+    hourly = []
+    for hour in range(1, 10):
+        hourly.append({
+            "dt": now + hour * 3600,
+            "temp": 70 + hour,
+            "feels_like": 70 + hour,
+            "pressure": 1014,
+            "humidity": 61,
+            "dew_point": 58,
+            "uvi": 4,
+            "clouds": 3,
+            "visibility": 10000,
+            "wind_speed": 8,
+            "wind_gust": 12,
+            "wind_deg": 90,
+            "weather": [{
+                "id": 800,
+                "main": "Clear",
+                "description": "clear sky",
+                "icon": "01d",
+            }],
+            "pop": 0.12,
+            "rain": {"1h": 0},
+        })
+
+    return {
+        "timezone": "America/New_York",
+        "timezone_offset": -14400,
+        "current": {
+            "dt": now,
+            "sunrise": now - 3600,
+            "sunset": now + 8 * 3600,
+            "temp": 72.6,
+            "feels_like": 73.1,
+            "pressure": 1014,
+            "humidity": 61,
+            "dew_point": 58,
+            "uvi": 4,
+            "clouds": 3,
+            "visibility": 10000,
+            "wind_speed": 8,
+            "wind_gust": 12,
+            "wind_deg": 90,
+            "weather": [{
+                "id": 800,
+                "main": "Clear",
+                "description": "clear sky",
+                "icon": "01d",
+            }],
+        },
+        "hourly": hourly,
+        "daily": [{
+            "moonrise": now + 1200,
+            "moonset": now + 43200,
+            "moon_phase": 0.5,
+            "summary": "E2E clear skies",
+        }],
+    }
+
+
+def tide_payload():
+    today = dt.date.today().isoformat()
+    return {
+        "predictions": [
+            {"t": f"{today} 03:17", "type": "L", "v": "0.1"},
+            {"t": f"{today} 09:24", "type": "H", "v": "4.2"},
+            {"t": f"{today} 15:41", "type": "L", "v": "0.3"},
+            {"t": f"{today} 21:58", "type": "H", "v": "4.0"},
+        ],
+    }
+
+
+def launch_payload():
+    return {
+        "results": [{
+            "window_start": rfc3339_utc(3600),
+            "window_end": rfc3339_utc(7200),
+            "name": "E2E Mission",
+            "pad": {
+                "name": "LC-39A, Kennedy Space Center",
+                "location": {"name": "Kennedy Space Center, FL, USA"},
+            },
+        }],
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/health":
+            self.write_json({"status": "healthy"})
+        elif path == "/weather":
+            self.write_json(weather_payload())
+        elif path == "/tide":
+            self.write_json(tide_payload())
+        elif path == "/tide-empty":
+            self.write_json({"predictions": []})
+        elif path.startswith("/launches/upcoming"):
+            self.write_json(launch_payload())
+        else:
+            self.send_error(404)
+
+    def write_json(self, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=18080)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,18 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Run unit tests
+      run: go test ./...
+
+    - name: Run e2e tests
+      run: .github/scripts/e2e.sh
+
     - name: Validate Conventional Commit messages
       shell: bash
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 COMPOSE ?= docker compose
 COMPOSE_FILE ?= docker-compose.yml
 
-.PHONY: docker-build docker-run docker-stop
+.PHONY: test e2e docker-build docker-run docker-stop
+
+test:
+	go test ./...
+
+e2e:
+	.github/scripts/e2e.sh
 
 docker-build:
 	$(COMPOSE) -f $(COMPOSE_FILE) build

--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ Optional environment variables:
    ./kindle-weather
    ```
 
+## Testing
+
+Run unit tests:
+
+```bash
+go test ./...
+```
+
+Run the local end-to-end check:
+
+```bash
+make e2e
+```
+
+The e2e check builds the binary, starts a local mock upstream API, runs the real
+HTTP server, and verifies the main page, static CSS, metrics, normal tide
+rendering, and the no-tide fallback. Pull requests targeting `main` run this
+check in CI before the Docker image build.
+
 ## Deployment
 
 ### Docker

--- a/kindle-weather.go
+++ b/kindle-weather.go
@@ -32,10 +32,12 @@ import (
 )
 
 const (
-	secretMountPath       = "/etc/secrets"
-	weatherAPIURLTemplate = "https://api.openweathermap.org/data/3.0/onecall?lat=29.65&lon=-81.20&exclude=minutely&appid=%s&units=imperial"
-	noaaAPIURLTemplate    = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?product=predictions&application=NOS.COOPS.TAC.WL&datum=MLLW&station=8720218&time_zone=lst_ldt&units=english&interval=hilo&format=json&date=today"
-	spacedevsAPIURL       = "https://ll.thespacedevs.com/2.3.0/launches/upcoming/?location__ids=27&format=json"
+	secretMountPath        = "/etc/secrets"
+	weatherAPIURLTemplate  = "https://api.openweathermap.org/data/3.0/onecall?lat=29.65&lon=-81.20&exclude=minutely&appid=%s&units=imperial"
+	noaaAPIURLTemplate     = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?product=predictions&application=NOS.COOPS.TAC.WL&datum=MLLW&station=8720218&time_zone=lst_ldt&units=english&interval=hilo&format=json&date=today"
+	spacedevsAPIURLDefault = "https://ll.thespacedevs.com/2.3.0/launches/upcoming/?location__ids=27&format=json"
+	tideCacheKeyLatest     = "latest-successful"
+	tideAPIMaxAttempts     = 3
 )
 
 //go:embed templates/*.html
@@ -44,6 +46,7 @@ var templatesFS embed.FS
 var (
 	weatherAPIURL       string
 	noaaAPIURL          string
+	spacedevsAPIURL     string
 	weatherCache        *cache.Cache
 	tideCache           *cache.Cache
 	launchCache         *cache.Cache
@@ -197,6 +200,7 @@ func init() {
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 	}
 	noaaAPIURL = noaaAPIURLTemplate
+	spacedevsAPIURL = spacedevsAPIURLDefault
 	weatherCache = cache.New(time.Hour, 2*time.Hour)
 	tideCache = cache.New(30*time.Minute, time.Hour)
 	launchCache = cache.New(15*time.Minute, time.Hour)
@@ -213,16 +217,28 @@ func init() {
 }
 
 func configureRuntime() error {
-	openWeatherAPIKey := strings.TrimSpace(os.Getenv("OPENWEATHER_API_KEY"))
-	if openWeatherAPIKey == "" {
-		var err error
-		openWeatherAPIKey, err = readSecret("openweather-api-key")
-		if err != nil {
-			return fmt.Errorf("failed to read OpenWeather API key: %w", err)
+	weatherAPIURL = strings.TrimSpace(os.Getenv("WEATHER_API_URL"))
+	if weatherAPIURL == "" {
+		openWeatherAPIKey := strings.TrimSpace(os.Getenv("OPENWEATHER_API_KEY"))
+		if openWeatherAPIKey == "" {
+			var err error
+			openWeatherAPIKey, err = readSecret("openweather-api-key")
+			if err != nil {
+				return fmt.Errorf("failed to read OpenWeather API key: %w", err)
+			}
 		}
+		weatherAPIURL = fmt.Sprintf(weatherAPIURLTemplate, openWeatherAPIKey)
 	}
-	weatherAPIURL = fmt.Sprintf(weatherAPIURLTemplate, openWeatherAPIKey)
-	noaaAPIURL = noaaAPIURLTemplate
+
+	noaaAPIURL = strings.TrimSpace(os.Getenv("NOAA_API_URL"))
+	if noaaAPIURL == "" {
+		noaaAPIURL = noaaAPIURLTemplate
+	}
+
+	spacedevsAPIURL = strings.TrimSpace(os.Getenv("SPACEDEVS_API_URL"))
+	if spacedevsAPIURL == "" {
+		spacedevsAPIURL = spacedevsAPIURLDefault
+	}
 
 	exp := parseEnvDurationSeconds("CACHE_EXPIRATION", time.Hour)
 	cleanup := parseEnvDurationSeconds("CACHE_CLEANUP_INTERVAL", 2*time.Hour)
@@ -627,34 +643,88 @@ func getTide(ctx context.Context) (TideData, error) {
 
 	tide, err := fetchTideFromAPI(ctx)
 	if err != nil {
+		if cachedData, found := tideCache.Get(tideCacheKeyLatest); found {
+			logJSON(logEntry{
+				Timestamp: time.Now().Format(time.RFC3339),
+				Level:     "WARN",
+				Message:   fmt.Sprintf("Using cached tide data after refresh failure: %v", err),
+			})
+			return cachedData.(TideData), nil
+		}
 		return TideData{}, err
 	}
 	tideCache.Set(cacheKey, tide, cache.DefaultExpiration)
+	tideCache.Set(tideCacheKeyLatest, tide, cache.NoExpiration)
 
 	return tide, nil
 }
 
 func fetchTideFromAPI(ctx context.Context) (TideData, error) {
+	tideURL, err := buildTideURL(noaaAPIURL)
+	if err != nil {
+		return TideData{}, err
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= tideAPIMaxAttempts; attempt++ {
+		tideData, retry, err := fetchTideAttempt(ctx, tideURL)
+		if err == nil {
+			return tideData, nil
+		}
+		lastErr = err
+		if !retry || attempt == tideAPIMaxAttempts || ctx.Err() != nil {
+			break
+		}
+
+		timer := time.NewTimer(time.Duration(attempt) * 250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return TideData{}, &APIError{URL: tideURL, Operation: "GET tide data", Err: ctx.Err()}
+		case <-timer.C:
+		}
+	}
+
+	return TideData{}, lastErr
+}
+
+func buildTideURL(baseURL string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", &APIError{URL: baseURL, Operation: "build tide request", Err: err}
+	}
+	q := u.Query()
+	q.Set("product", "predictions")
+	q.Set("datum", "MLLW")
+	q.Set("units", "english")
+	q.Set("time_zone", "lst_ldt")
+	q.Set("interval", "hilo")
+	q.Set("format", "json")
+	if q.Get("date") == "" {
+		q.Set("date", "today")
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func fetchTideAttempt(ctx context.Context, tideURL string) (TideData, bool, error) {
 	apiRequestsTotal.WithLabelValues("tide").Inc()
 
-	// Add height to URL parameters
-	noaaURLWithHeight := noaaAPIURL + "&datatype=hilo&datum=MLLW"
-
-	req, err := http.NewRequest(http.MethodGet, noaaURLWithHeight, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tideURL, nil)
 	if err != nil {
-		return TideData{}, &APIError{URL: noaaURLWithHeight, Operation: "build tide request", Err: err}
+		return TideData{}, false, &APIError{URL: tideURL, Operation: "build tide request", Err: err}
 	}
-	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "kindle-weather/1.0")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return TideData{}, &APIError{URL: noaaURLWithHeight, Operation: "GET tide data", Err: err}
+		return TideData{}, true, &APIError{URL: tideURL, Operation: "GET tide data", Err: err}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return TideData{}, &APIError{URL: noaaURLWithHeight, Operation: "GET tide data", Err: fmt.Errorf("status code %d", resp.StatusCode)}
+		retry := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode >= http.StatusInternalServerError
+		return TideData{}, retry, &APIError{URL: tideURL, Operation: "GET tide data", Err: fmt.Errorf("status code %d", resp.StatusCode)}
 	}
 
 	var rawData struct {
@@ -666,15 +736,15 @@ func fetchTideFromAPI(ctx context.Context) (TideData, error) {
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&rawData); err != nil {
-		return TideData{}, &APIError{URL: noaaURLWithHeight, Operation: "decode tide data", Err: err}
+		return TideData{}, true, &APIError{URL: tideURL, Operation: "decode tide data", Err: err}
 	}
 
 	tideData, err := processTideData(rawData)
 	if err != nil {
-		return TideData{}, err
+		return TideData{}, false, err
 	}
 
-	return tideData, nil
+	return tideData, false, nil
 }
 
 func processTideData(rawData struct {
@@ -689,25 +759,32 @@ func processTideData(rawData struct {
 		return TideData{}, &APIError{URL: noaaAPIURL, Operation: "process tide data", Err: fmt.Errorf("no predictions found")}
 	}
 
+	var skipped []string
 	for _, p := range rawData.Predictions {
 		if p.Type != "H" && p.Type != "L" {
-			return TideData{}, &APIError{URL: noaaAPIURL, Operation: "process tide data", Err: fmt.Errorf("invalid tide type: %s", p.Type)}
+			skipped = append(skipped, fmt.Sprintf("invalid tide type %q", p.Type))
+			continue
 		}
 
 		itemTime, err := time.Parse("2006-01-02 15:04", p.Time)
 		if err != nil {
-			return TideData{}, &APIError{URL: noaaAPIURL, Operation: "parse tide time", Err: err}
+			skipped = append(skipped, fmt.Sprintf("invalid tide time %q", p.Time))
+			continue
 		}
 
 		height, err := strconv.ParseFloat(p.Height, 64)
 		if err != nil {
-			return TideData{}, &APIError{URL: noaaAPIURL, Operation: "parse tide height", Err: err}
+			skipped = append(skipped, fmt.Sprintf("invalid tide height %q", p.Height))
+			continue
 		}
 		tideData.Predictions = append(tideData.Predictions, TidePrediction{
 			Time:   itemTime.Format("3:04 PM"),
 			Type:   p.Type,
 			Height: height,
 		})
+	}
+	if len(tideData.Predictions) == 0 {
+		return TideData{}, &APIError{URL: noaaAPIURL, Operation: "process tide data", Err: fmt.Errorf("no valid predictions found: %s", strings.Join(skipped, "; "))}
 	}
 
 	return tideData, nil
@@ -768,11 +845,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logJSON(logEntry{
 			Timestamp: time.Now().Format(time.RFC3339),
-			Level:     "ERROR",
+			Level:     "WARN",
 			Message:   fmt.Sprintf("Error getting tide data: %v", err),
 		})
-		http.Error(w, "Could not get tide data", http.StatusInternalServerError)
-		return
 	}
 
 	kennedyLaunch, err := getTodayKennedyLaunch(ctx)
@@ -795,11 +870,10 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logJSON(logEntry{
 			Timestamp: time.Now().Format(time.RFC3339),
-			Level:     "ERROR",
+			Level:     "WARN",
 			Message:   fmt.Sprintf("Error generating tide SVG: %v", err),
 		})
-		http.Error(w, "Could not generate tide chart", http.StatusInternalServerError)
-		return
+		tideSVG = tideUnavailableSVG()
 	}
 
 	horizontal := r.URL.Query().Has("h")
@@ -836,7 +910,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func generateTideSVG(predictions []TidePrediction) (template.HTML, error) {
 	if len(predictions) == 0 {
-		return "", fmt.Errorf("no tide predictions to render")
+		return tideUnavailableSVG(), nil
 	}
 	const svgTemplate = `
     <svg width="600" height="95" viewBox="0 0 600 95">
@@ -939,6 +1013,14 @@ func generateTideSVG(predictions []TidePrediction) (template.HTML, error) {
 	}
 
 	return template.HTML(buf.String()), nil
+}
+
+func tideUnavailableSVG() template.HTML {
+	return template.HTML(`
+    <svg width="600" height="95" viewBox="0 0 600 95">
+        <line x1="35" y1="44" x2="565" y2="44" stroke="black" stroke-width="1" stroke-dasharray="6 6" />
+        <text x="300" y="48" font-size="14" text-anchor="middle" font-weight="bold">Tide data unavailable</text>
+    </svg>`)
 }
 
 func main() {

--- a/kindle_test.go
+++ b/kindle_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"html/template"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
@@ -176,6 +178,37 @@ func TestProcessTideData_InvalidHeight(t *testing.T) {
 	}
 }
 
+func TestProcessTideData_SkipsInvalidPredictions(t *testing.T) {
+	rawData := struct {
+		Predictions []struct {
+			Time   string `json:"t"`
+			Type   string `json:"type"`
+			Height string `json:"v"`
+		} `json:"predictions"`
+	}{
+		Predictions: []struct {
+			Time   string `json:"t"`
+			Type   string `json:"type"`
+			Height string `json:"v"`
+		}{
+			{Time: "2024-01-01 13:45", Type: "H", Height: "4.2"},
+			{Time: "bad-time", Type: "L", Height: "0.2"},
+			{Time: "2024-01-01 19:30", Type: "X", Height: "0.2"},
+		},
+	}
+
+	data, err := processTideData(rawData)
+	if err != nil {
+		t.Fatalf("processTideData() error = %v", err)
+	}
+	if len(data.Predictions) != 1 {
+		t.Fatalf("got %d valid predictions; want 1", len(data.Predictions))
+	}
+	if data.Predictions[0].Time != "1:45 PM" || data.Predictions[0].Type != "H" {
+		t.Fatalf("unexpected prediction: %+v", data.Predictions[0])
+	}
+}
+
 func TestGenerateTideSVG_CompactLayout(t *testing.T) {
 	svg, err := generateTideSVG([]TidePrediction{
 		{Time: "3:17 AM", Type: "L", Height: 0.1},
@@ -203,6 +236,52 @@ func TestGenerateTideSVG_CompactLayout(t *testing.T) {
 	}
 	if strings.Contains(rendered, "<polyline") {
 		t.Fatalf("generated tide SVG should use a curved path, got: %s", rendered)
+	}
+}
+
+func TestGenerateTideSVG_NoPredictionsRendersFallback(t *testing.T) {
+	svg, err := generateTideSVG(nil)
+	if err != nil {
+		t.Fatalf("generateTideSVG() error = %v", err)
+	}
+
+	if !strings.Contains(string(svg), "Tide data unavailable") {
+		t.Fatalf("generated tide fallback missing unavailable text: %s", svg)
+	}
+}
+
+func TestFetchTideFromAPI_RetriesTransientFailure(t *testing.T) {
+	oldNOAAURL := noaaAPIURL
+	oldHTTPClient := httpClient
+	defer func() {
+		noaaAPIURL = oldNOAAURL
+		httpClient = oldHTTPClient
+	}()
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"t":"2024-01-01 13:45","type":"H","v":"4.2"}]}`))
+	}))
+	defer server.Close()
+
+	noaaAPIURL = server.URL + "?station=8720218"
+	httpClient = server.Client()
+
+	data, err := fetchTideFromAPI(context.Background())
+	if err != nil {
+		t.Fatalf("fetchTideFromAPI() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("fetchTideFromAPI() attempts = %d; want 2", attempts)
+	}
+	if len(data.Predictions) != 1 {
+		t.Fatalf("got %d predictions; want 1", len(data.Predictions))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make tide fetching resilient with transient retries, safer NOAA URL construction, and last-successful tide cache fallback.
- Let the Kindle page render when tide data is unavailable by showing a compact SVG fallback instead of returning HTTP 500.
- Add a mock-backed e2e harness and wire it into PR CI before the Docker image build.

## Validation
- `make test`
- `make e2e`

## Notes
The e2e check uses local mock upstreams via `WEATHER_API_URL`, `NOAA_API_URL`, and `SPACEDEVS_API_URL`, so PR checks do not depend on repository secrets or live third-party APIs.
